### PR TITLE
sandbox: add SYS_newfstatat to seccomp whitelist

### DIFF
--- a/src/daemon/sandbox.rs
+++ b/src/daemon/sandbox.rs
@@ -243,6 +243,7 @@ mod imp {
             libc::SYS_fcntl,
             libc::SYS_lseek,
             libc::SYS_fstat,
+            libc::SYS_newfstatat,
             libc::SYS_statx,
             libc::SYS_flock,
             libc::SYS_ftruncate,


### PR DESCRIPTION
With this change, I'm able to run this fine on a ubuntu 22.04 VM with glibc 2.35 and kernel 6.8. 