### PR TITLE
boot: add --append flag for extra kernel bootargs

### DIFF
--- a/src/boot.rs
+++ b/src/boot.rs
@@ -252,6 +252,7 @@ pub fn modify_dtb(
     virtio_nodes: &[VirtioMmioNode],
     uart_addr: Option<u64>,
     virtio_console_attached: bool,
+    extra_bootargs: Option<&str>,
 ) -> crate::Result<Vec<u8>> {
     let mem_end = mem_start + mem_size;
     crate::dlog!(
@@ -310,7 +311,7 @@ pub fn modify_dtb(
     } else {
         "earlycon=sbi keep_bootcon"
     };
-    let bootargs = match boot_device {
+    let base_bootargs = match boot_device {
         BootDevice::Vda(dev) => {
             format!("rw {} root=/dev/{}", console_args, dev)
         }
@@ -323,10 +324,15 @@ pub fn modify_dtb(
         ),
         BootDevice::Uboot => console_args.to_string(),
     };
+    let bootargs = match extra_bootargs {
+        Some(extra) if !extra.is_empty() => format!("{} {}", base_bootargs, extra),
+        _ => base_bootargs,
+    };
     crate::dlog!(
-        "[modify_dtb]   bootargs = {:?} (virtio_console_attached={})",
+        "[modify_dtb]   bootargs = {:?} (virtio_console_attached={}, extra={:?})",
         bootargs,
-        virtio_console_attached
+        virtio_console_attached,
+        extra_bootargs,
     );
     let mut bootargs_bytes = bootargs.into_bytes();
     bootargs_bytes.push(0);
@@ -709,7 +715,17 @@ mod tests {
         let mem_start = 0x4000_3000_0000u64;
         let mem_size = 0x8000_0000u64; // 2 GiB
         let dev = BootDevice::Vda("vda".to_string());
-        let out = modify_dtb(FIXTURE_DTB, &dev, mem_start, mem_size, &[], None, true).unwrap();
+        let out = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         assert_eq!(read_memory_reg(&out, mem_start), (mem_start, mem_size));
     }
 
@@ -723,7 +739,17 @@ mod tests {
         let mem_start = 0x4000_3000_0000u64;
         let override_size = 0x4000_0000u64; // 1 GiB instead of physical 4 GiB
         let dev = BootDevice::Vda("vda".to_string());
-        let out = modify_dtb(FIXTURE_DTB, &dev, mem_start, override_size, &[], None, true).unwrap();
+        let out = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            override_size,
+            &[],
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         assert_eq!(read_memory_reg(&out, mem_start), (mem_start, override_size));
     }
 
@@ -741,7 +767,17 @@ mod tests {
         let mem_start = 0x4000_3000_0000u64;
         let mem_size = 0x1_0000_0000u64;
         let dev = BootDevice::Vda("vda".to_string());
-        let out = modify_dtb(FIXTURE_DTB, &dev, mem_start, mem_size, &[], None, true).unwrap();
+        let out = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            true,
+            None,
+        )
+        .unwrap();
 
         let fdt = Fdt::open_into(&out, 0).unwrap();
         let path = format!("/reserved-memory/bhx-opensbi-firmware@{:x}", mem_start);
@@ -771,7 +807,17 @@ mod tests {
         let mem_start = 0x4000_3000_0000u64;
         let mem_size = 0x1_0000_0000u64;
         let dev = BootDevice::Vda("vda".to_string());
-        let cold = modify_dtb(FIXTURE_DTB, &dev, mem_start, mem_size, &[], None, true).unwrap();
+        let cold = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         let path = format!("/reserved-memory/bhx-opensbi-firmware@{:x}", mem_start);
         let pre = Fdt::open_into(&cold, 0).unwrap();
         assert!(pre.path_offset(&path).unwrap().is_none());
@@ -805,7 +851,17 @@ mod tests {
         let mem_start = 0x4000_b000_0000u64;
         let mem_size = 0x8000_0000u64;
         let dev = BootDevice::Vda("vda".to_string());
-        let out = modify_dtb(FIXTURE_DTB, &dev, mem_start, mem_size, &[], None, true).unwrap();
+        let out = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         assert_eq!(read_memory_reg(&out, mem_start), (mem_start, mem_size));
 
         let fdt = Fdt::open_into(&out, 0).unwrap();
@@ -830,6 +886,7 @@ mod tests {
             &[],
             None,
             true,
+            None,
         )
         .unwrap();
         let fdt = Fdt::open_into(&out, 0).unwrap();
@@ -859,6 +916,7 @@ mod tests {
             &[],
             None,
             true,
+            None,
         )
         .unwrap();
         let fdt = Fdt::open_into(&out, 0).unwrap();
@@ -881,7 +939,17 @@ mod tests {
         let expected_base = mem_end - crate::regs::virtio_mmio::RESERVED_SIZE;
 
         let dev = BootDevice::Vda("vda".to_string());
-        let out = modify_dtb(FIXTURE_DTB, &dev, mem_start, mem_size, &[], None, true).unwrap();
+        let out = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         let fdt = Fdt::open_into(&out, 0).unwrap();
         let res = fdt
             .path_offset("/reserved-memory/memory@4000afa00000")
@@ -917,7 +985,17 @@ mod tests {
                 irq: DISK_IRQ - i as u32,
             })
             .collect();
-        let out = modify_dtb(FIXTURE_DTB, &dev, mem_start, mem_size, &nodes, None, true).unwrap();
+        let out = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &nodes,
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         let fdt = Fdt::open_into(&out, 0).unwrap();
 
         for spec in &nodes {
@@ -948,7 +1026,17 @@ mod tests {
         let mem_start = 0x4000_3000_0000u64;
         let mem_size = 0x1_0000_0000u64;
         let dev = BootDevice::Vda("vda".to_string());
-        let out = modify_dtb(FIXTURE_DTB, &dev, mem_start, mem_size, &[], None, false).unwrap();
+        let out = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            false,
+            None,
+        )
+        .unwrap();
         let fdt = Fdt::open_into(&out, 0).unwrap();
         let chosen = fdt.path_offset("/chosen").unwrap().unwrap();
         let args = fdt.getprop(chosen, "bootargs").unwrap();
@@ -983,7 +1071,17 @@ mod tests {
         let mem_start = 0x4000_3000_0000u64;
         let mem_size = 0x1_0000_0000u64;
         let dev = BootDevice::Vda("vda".to_string());
-        let out = modify_dtb(FIXTURE_DTB, &dev, mem_start, mem_size, &[], None, true).unwrap();
+        let out = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         let fdt = Fdt::open_into(&out, 0).unwrap();
         for i in 0..4u64 {
             let addr = mem_start + mem_size - crate::regs::virtio_mmio::MMIO_SLOT_SIZE * (i + 1);
@@ -1012,7 +1110,17 @@ mod tests {
         // the verify call from modify_dtb's return path.
         let mem_start = 0x4000_3000_0000u64;
         let dev = BootDevice::Vda("vda".to_string());
-        let dtb = modify_dtb(FIXTURE_DTB, &dev, mem_start, 0x1_0000_0000, &[], None, true).unwrap();
+        let dtb = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            0x1_0000_0000,
+            &[],
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         verify_dtb_invariants(&dtb, mem_start).expect("happy-path DTB must verify");
     }
 
@@ -1030,6 +1138,89 @@ mod tests {
             msg.contains("bhx-purgatory"),
             "expected bhx-purgatory complaint, got {:?}",
             msg
+        );
+    }
+
+    #[test]
+    fn modify_dtb_extra_bootargs_appended() {
+        let mem_start = 0x4000_3000_0000u64;
+        let mem_size = 0x1_0000_0000u64;
+        let dev = BootDevice::Vda("vda".to_string());
+        let out = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            true,
+            Some("loglevel=7 systemd.debug-shell=1"),
+        )
+        .unwrap();
+        let fdt = Fdt::open_into(&out, 0).unwrap();
+        let chosen = fdt.path_offset("/chosen").unwrap().unwrap();
+        let args = fdt.getprop(chosen, "bootargs").unwrap();
+        let s = std::str::from_utf8(&args[..args.len() - 1]).unwrap();
+        assert!(
+            s.contains("loglevel=7"),
+            "bootargs missing loglevel: {:?}",
+            s
+        );
+        assert!(
+            s.contains("systemd.debug-shell=1"),
+            "bootargs missing systemd.debug-shell: {:?}",
+            s
+        );
+        // Base args must still be present.
+        assert!(
+            s.contains("root=/dev/vda"),
+            "bootargs missing root: {:?}",
+            s
+        );
+        assert!(
+            s.contains("console=hvc0"),
+            "bootargs missing console: {:?}",
+            s
+        );
+    }
+
+    #[test]
+    fn modify_dtb_empty_extra_bootargs_unchanged() {
+        // An empty string extra_bootargs must not add a trailing space.
+        let mem_start = 0x4000_3000_0000u64;
+        let mem_size = 0x1_0000_0000u64;
+        let dev = BootDevice::Vda("vda".to_string());
+        let base = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            true,
+            None,
+        )
+        .unwrap();
+        let with_empty = modify_dtb(
+            FIXTURE_DTB,
+            &dev,
+            mem_start,
+            mem_size,
+            &[],
+            None,
+            true,
+            Some(""),
+        )
+        .unwrap();
+        let fdt_base = Fdt::open_into(&base, 0).unwrap();
+        let fdt_empty = Fdt::open_into(&with_empty, 0).unwrap();
+        let chosen_base = fdt_base.path_offset("/chosen").unwrap().unwrap();
+        let chosen_empty = fdt_empty.path_offset("/chosen").unwrap().unwrap();
+        let args_base = fdt_base.getprop(chosen_base, "bootargs").unwrap();
+        let args_empty = fdt_empty.getprop(chosen_empty, "bootargs").unwrap();
+        assert_eq!(
+            args_base, args_empty,
+            "empty extra_bootargs must not change the cmdline"
         );
     }
 }

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -66,13 +66,14 @@ pub fn boot(
     memory_override: Option<u64>,
     hostname_override: Option<String>,
     cloud_init: Option<String>,
+    extra_bootargs: Option<String>,
 ) -> io::Result<()> {
     write_frame(
         &mut *sock,
         &Request::Boot {
             l2cpu,
             opensbi,
-            payload,
+            payload: Box::new(payload),
             dtb,
             initramfs,
             root_device,
@@ -85,6 +86,7 @@ pub fn boot(
             memory_override,
             hostname_override,
             cloud_init,
+            extra_bootargs,
         },
     )?;
     expect_ok(read_frame(&mut *sock)?)

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -34,7 +34,7 @@ pub enum Request {
         /// at runtime. In `Uboot` mode the daemon does not preload an
         /// initramfs and `modify_dtb` leaves bootargs to U-Boot. See
         /// #44 for the umbrella.
-        payload: BootPayload,
+        payload: Box<BootPayload>,
         dtb: String,
         /// Initramfs to preload into DRAM. Ignored in `Uboot` mode
         /// (U-Boot reads the initrd from disk).
@@ -101,6 +101,11 @@ pub enum Request {
         /// clients deserialize without this field via `serde(default)`.
         #[serde(default)]
         cloud_init: Option<String>,
+        /// Extra kernel command-line parameters appended verbatim after
+        /// the daemon-generated bootargs. Older clients that omit this
+        /// field deserialize to `None` via `serde(default)`.
+        #[serde(default)]
+        extra_bootargs: Option<String>,
     },
     /// Attach a console fd. Daemon replies with `ok` and sends the fd via
     /// SCM_RIGHTS; client pumps bytes between its tty and the passed fd.
@@ -470,7 +475,7 @@ mod tests {
         let req = Request::Boot {
             l2cpu: 2,
             opensbi: "fw_jump.bin".into(),
-            payload: BootPayload::Kernel("Image".into()),
+            payload: Box::new(BootPayload::Kernel("Image".into())),
             dtb: "blackhole-card.dtb".into(),
             initramfs: None,
             root_device: "vda".into(),
@@ -483,18 +488,19 @@ mod tests {
             memory_override: None,
             hostname_override: None,
             cloud_init: None,
+            extra_bootargs: None,
         };
         let mut buf = Vec::new();
         write_frame(&mut buf, &req).unwrap();
         let decoded: Request = read_frame(Cursor::new(&buf)).unwrap();
-        assert!(matches!(
-            decoded,
+        match decoded {
             Request::Boot {
                 l2cpu: 2,
-                payload: BootPayload::Kernel(_),
+                ref payload,
                 ..
-            }
-        ));
+            } => assert!(matches!(*payload.as_ref(), BootPayload::Kernel(_))),
+            other => panic!("expected Boot variant, got {:?}", other),
+        }
     }
 
     #[test]
@@ -502,7 +508,7 @@ mod tests {
         let req = Request::Boot {
             l2cpu: 0,
             opensbi: "fw_jump.bin".into(),
-            payload: BootPayload::Uboot("u-boot.bin".into()),
+            payload: Box::new(BootPayload::Uboot("u-boot.bin".into())),
             dtb: "blackhole-card.dtb".into(),
             initramfs: None,
             root_device: "vda".into(),
@@ -515,16 +521,17 @@ mod tests {
             memory_override: None,
             hostname_override: None,
             cloud_init: None,
+            extra_bootargs: None,
         };
         let mut buf = Vec::new();
         write_frame(&mut buf, &req).unwrap();
         let decoded: Request = read_frame(Cursor::new(&buf)).unwrap();
         match decoded {
-            Request::Boot {
-                payload: BootPayload::Uboot(p),
-                ..
-            } => assert_eq!(p, "u-boot.bin"),
-            other => panic!("expected uboot variant, got {:?}", other),
+            Request::Boot { payload, .. } => match *payload {
+                BootPayload::Uboot(p) => assert_eq!(p, "u-boot.bin"),
+                other => panic!("expected Uboot variant, got {:?}", other),
+            },
+            other => panic!("expected Boot variant, got {:?}", other),
         }
     }
 
@@ -703,7 +710,7 @@ mod tests {
             let req = Request::Boot {
                 l2cpu: 1,
                 opensbi: "a".into(),
-                payload: BootPayload::Kernel("b".into()),
+                payload: Box::new(BootPayload::Kernel("b".into())),
                 dtb: "c".into(),
                 initramfs: None,
                 root_device: "vda".into(),
@@ -716,6 +723,7 @@ mod tests {
                 memory_override: None,
                 hostname_override: None,
                 cloud_init: None,
+                extra_bootargs: None,
             };
             let mut buf = Vec::new();
             write_frame(&mut buf, &req).unwrap();
@@ -811,7 +819,7 @@ mod tests {
         let req = Request::Boot {
             l2cpu: 0,
             opensbi: "a".into(),
-            payload: BootPayload::Kernel("b".into()),
+            payload: Box::new(BootPayload::Kernel("b".into())),
             dtb: "c".into(),
             initramfs: None,
             root_device: "vda".into(),
@@ -824,6 +832,7 @@ mod tests {
             memory_override: Some(0x4000_0000),
             hostname_override: Some("debian-bench".into()),
             cloud_init: None,
+            extra_bootargs: None,
         };
         let mut buf = Vec::new();
         write_frame(&mut buf, &req).unwrap();
@@ -850,5 +859,53 @@ mod tests {
         assert_eq!(s, r#""wedged""#);
         let parsed: L2CpuState = serde_json::from_str(r#""wedged""#).unwrap();
         assert_eq!(parsed, L2CpuState::Wedged);
+    }
+
+    #[test]
+    fn boot_extra_bootargs_roundtrips() {
+        let req = Request::Boot {
+            l2cpu: 0,
+            opensbi: "a".into(),
+            payload: Box::new(BootPayload::Kernel("b".into())),
+            dtb: "c".into(),
+            initramfs: None,
+            root_device: "vda".into(),
+            disk: None,
+            network: false,
+            extra_fwd: vec![],
+            console: true,
+            rng: false,
+            force: false,
+            memory_override: None,
+            hostname_override: None,
+            cloud_init: None,
+            extra_bootargs: Some("loglevel=7 systemd.debug-shell=1".into()),
+        };
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &req).unwrap();
+        let decoded: Request = read_frame(Cursor::new(&buf)).unwrap();
+        match decoded {
+            Request::Boot { extra_bootargs, .. } => {
+                assert_eq!(
+                    extra_bootargs.as_deref(),
+                    Some("loglevel=7 systemd.debug-shell=1")
+                );
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn boot_extra_bootargs_defaults_none_on_old_payload() {
+        // Older clients that omit extra_bootargs must still decode
+        // successfully; the field must default to None.
+        let json = r#"{"op":"boot","l2cpu":0,"opensbi":"a","payload":{"kind":"kernel","path":"b"},"dtb":"c","root_device":"vda"}"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        match req {
+            Request::Boot { extra_bootargs, .. } => {
+                assert!(extra_bootargs.is_none());
+            }
+            _ => panic!("wrong variant"),
+        }
     }
 }

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -327,6 +327,7 @@ fn handle_client(mut sock: UnixStream, state: Arc<DaemonState>) {
             memory_override,
             hostname_override,
             cloud_init,
+            extra_bootargs,
         } => dispatch_boot(
             &sock,
             &state,
@@ -345,6 +346,7 @@ fn handle_client(mut sock: UnixStream, state: Arc<DaemonState>) {
             memory_override,
             hostname_override,
             cloud_init,
+            extra_bootargs,
         ),
         Request::AttachConsole { l2cpu, mode } => {
             dispatch_attach_console(&sock, &state, l2cpu, mode)
@@ -791,6 +793,7 @@ fn dispatch_boot(
     memory_override: Option<u64>,
     hostname_override: Option<String>,
     cloud_init: Option<String>,
+    extra_bootargs: Option<String>,
 ) -> crate::Result<()> {
     // U-Boot mode reads kernel + initrd from disk at runtime, so the
     // daemon's preloaded initramfs would be unreachable. Reject up
@@ -804,8 +807,8 @@ fn dispatch_boot(
         initramfs
     };
     dlog!(
-        "[boot l2cpu {}] dispatch_boot entry: opensbi={} payload={:?} dtb={} initramfs={:?} root={} disk={:?} network={} console={} rng={} force={} mem_override={:?} hostname_override={:?} cloud_init={:?}",
-        l2cpu_idx, opensbi, payload, dtb, initramfs, root_device, disk, network, console, rng, force, memory_override, hostname_override, cloud_init
+        "[boot l2cpu {}] dispatch_boot entry: opensbi={} payload={:?} dtb={} initramfs={:?} root={} disk={:?} network={} console={} rng={} force={} mem_override={:?} hostname_override={:?} cloud_init={:?} extra_bootargs={:?}",
+        l2cpu_idx, opensbi, payload, dtb, initramfs, root_device, disk, network, console, rng, force, memory_override, hostname_override, cloud_init, extra_bootargs
     );
     validate_l2cpu(l2cpu_idx)?;
 
@@ -889,6 +892,7 @@ fn dispatch_boot(
         rng,
         cloud_init.is_some(),
         memory_override,
+        extra_bootargs.as_deref(),
     )
     .map_err(|e| {
         dlog!("[boot l2cpu {}] boot sequence failed: {}", l2cpu_idx, e);
@@ -1804,6 +1808,7 @@ fn run_boot_sequence(
     has_rng: bool,
     has_cidata: bool,
     memory_override: Option<u64>,
+    extra_bootargs: Option<&str>,
 ) -> io::Result<BootArtifacts> {
     use crate::regs::boot_image;
 
@@ -2048,6 +2053,7 @@ fn run_boot_sequence(
         &virtio_nodes,
         uart_addr_for_dtb,
         has_console,
+        extra_bootargs,
     )?;
 
     let initramfs_pb = initramfs.map(std::path::PathBuf::from);

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,16 @@ enum Commands {
         /// auto-attach entirely).
         #[arg(long = "no-cidata")]
         no_cidata: bool,
+        /// Extra kernel command-line parameters appended after the
+        /// daemon-generated bootargs.
+        ///
+        /// The daemon already sets `console=`, `earlycon=`, `root=`,
+        /// and `initrd=` based on the boot mode. Use `--append` to
+        /// tack on anything extra, e.g.
+        /// `--append "loglevel=7 systemd.debug-shell=1"`.
+        /// The string is appended verbatim with a single space separator.
+        #[arg(long = "append")]
+        append: Option<String>,
     },
     /// Attach a terminal to a booted L2CPU's console via the daemon.
     Connect {
@@ -856,6 +866,7 @@ fn main() -> std::process::ExitCode {
             profile,
             cloud_init,
             no_cidata,
+            append,
         }) => {
             let (card, l2cpu) = resolve_target(&cli.l2cpu, cli.ttdevice)?;
             // `--image <name>` is a registry-name shortcut: resolve
@@ -970,6 +981,7 @@ fn main() -> std::process::ExitCode {
                 memory,
                 hostname,
                 cloud_init,
+                append,
             )?;
             if attach {
                 run_connect_client(card, l2cpu, daemon::protocol::ConsoleMode::Rw)?;
@@ -1254,6 +1266,7 @@ fn run_boot_client(
     memory_override: Option<u64>,
     hostname_override: Option<String>,
     cloud_init: Option<String>,
+    extra_bootargs: Option<String>,
 ) -> std::io::Result<()> {
     // Bundle disk + network into the Boot RPC so the virtio workers come up
     // together with the L2CPU reset release. The guest kernel hits its VFS
@@ -1298,6 +1311,7 @@ fn run_boot_client(
         memory_override,
         hostname_override,
         cloud_init,
+        extra_bootargs,
     )
 }
 
@@ -2949,6 +2963,7 @@ fn run_boot_via_profile(
         memory_override,
         hostname_override,
         cloud_init_path,
+        None,
     )
 }
 


### PR DESCRIPTION
Adds the ability to extend the kernel commandline while doing `bhx boot`